### PR TITLE
feat: add jsonschema templates to seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ Thumbs.db
 demodata/*
 pat.env
 
+# Builds
+datum-cloud-cli
+datum-cloud
+
 # Configs
 *.env
 *.env-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "internal/seed/templates"]
+	path = internal/seed/templates
+	url = https://github.com/datumforge/jsonschema-templates.git

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,4 +40,5 @@ issues:
     - .buildkite/*
     - .github/*
     - docker/*
+    - internal/seed/jsonschema/templates/*
   exclude-files: []

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,5 +40,4 @@ issues:
     - .buildkite/*
     - .github/*
     - docker/*
-    - internal/seed/jsonschema/templates/*
   exclude-files: []

--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -15,6 +15,11 @@ tasks:
     cmds:
       - go run cmd/cli/main.go seed init
 
+  template:
+    desc: initialize the new seeded template data
+    cmds:
+      - go run cmd/cli/main.go seed templates
+
   seed:
     desc: create a new seeded environment
     cmds:

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/."+appName+".yaml)")
 	RootCmd.PersistentFlags().String("host", "", "datum cloud api url, if not set the config default will be used")
-	RootCmd.PersistentFlags().String("datum-host", "", "datum api url, if not set the config default will be used")
+	RootCmd.PersistentFlags().String("datumhost", "", "datum api url, if not set the config default will be used")
 
 	// Auth flags
 	RootCmd.Flags().String("token", "", "datum api token")

--- a/cmd/cli/cmd/seed/seed_init.go
+++ b/cmd/cli/cmd/seed/seed_init.go
@@ -114,6 +114,12 @@ func initSeedData(ctx context.Context) error {
 	err = c.LoadSubscribers(ctx)
 	cobra.CheckErr(err)
 
+	bar.Describe("[light_green]>[reset] creating templates...")
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	err = c.LoadTemplates(ctx)
+	cobra.CheckErr(err)
+
 	bar.Describe("[light_green]>[reset] seeded environment created")
 	err = bar.Finish()
 	cobra.CheckErr(err)
@@ -186,6 +192,18 @@ func getAllData(ctx context.Context, c *seed.Client) error {
 
 	createTableOutput("Subscribers", header, rows)
 
+	templates, err := c.GetAllTemplates(ctx)
+	cobra.CheckErr(err)
+
+	header = table.Row{"ID", "Name"}
+	rows = []table.Row{}
+
+	for _, template := range templates.Templates.Edges {
+		rows = append(rows, []interface{}{template.Node.ID, template.Node.Name})
+	}
+
+	createTableOutput("Templates", header, rows)
+
 	return nil
 }
 
@@ -204,8 +222,8 @@ func newSeedClient() (*seed.Client, error) {
 		conf.Directory = datumcloud.Config.String("directory")
 	}
 
-	if datumcloud.Config.String("datum-host") != "" {
-		conf.DatumHost = datumcloud.Config.String("datum-host")
+	if datumcloud.Config.String("datumhost") != "" {
+		conf.DatumHost = datumcloud.Config.String("datumhost")
 	}
 
 	conf.Token = datumcloud.Config.String("token")

--- a/cmd/cli/cmd/seed/seed_templates.go
+++ b/cmd/cli/cmd/seed/seed_templates.go
@@ -2,6 +2,7 @@ package datumseed
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/schollz/progressbar/v3"
@@ -69,6 +70,9 @@ func getAllTemplateData(ctx context.Context, c *seed.Client) error {
 	for _, template := range templates.Templates.Edges {
 		rows = append(rows, []interface{}{template.Node.ID, template.Node.Name})
 	}
+
+	// add empty row for spacing
+	fmt.Println()
 
 	createTableOutput("Templates", header, rows)
 

--- a/cmd/cli/cmd/seed/seed_templates.go
+++ b/cmd/cli/cmd/seed/seed_templates.go
@@ -1,0 +1,76 @@
+package datumseed
+
+import (
+	"context"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/schollz/progressbar/v3"
+	"github.com/spf13/cobra"
+
+	datumcloud "github.com/datumforge/datum-cloud/cmd/cli/cmd"
+	"github.com/datumforge/datum-cloud/internal/seed"
+)
+
+var seedTemplateCmd = &cobra.Command{
+	Use:   "templates",
+	Short: "add templates to an existing seeded environment",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return initTemplateData(cmd.Context())
+	},
+}
+
+func init() {
+	seedCmd.AddCommand(seedTemplateCmd)
+}
+
+func initTemplateData(ctx context.Context) error {
+	c, err := newSeedClient()
+	cobra.CheckErr(err)
+
+	bar := progressbar.NewOptions(100, //nolint:mnd
+		progressbar.OptionEnableColorCodes(true),
+		progressbar.OptionShowBytes(false),
+		progressbar.OptionSetWidth(15), //nolint:mnd
+		progressbar.OptionShowElapsedTimeOnFinish(),
+		progressbar.OptionSetDescription("[light_green]>[reset] creating seeded templates..."),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "[light_green]=[reset]",
+			SaucerHead:    "[light_green]>[reset]",
+			SaucerPadding: " ",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}),
+	)
+	defer bar.Exit() //nolint:errcheck
+
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	bar.Describe("[light_green]>[reset] creating templates...")
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	err = c.LoadTemplates(ctx)
+	cobra.CheckErr(err)
+
+	bar.Describe("[light_green]>[reset] seeded environment created")
+	err = bar.Finish()
+	cobra.CheckErr(err)
+
+	return getAllTemplateData(ctx, c)
+}
+
+// getAllTemplateData gets all the data from the seeded environment in a table format
+func getAllTemplateData(ctx context.Context, c *seed.Client) error {
+	templates, err := c.GetAllTemplates(ctx)
+	cobra.CheckErr(err)
+
+	header := table.Row{"ID", "Name"}
+	rows := []table.Row{}
+
+	for _, template := range templates.Templates.Edges {
+		rows = append(rows, []interface{}{template.Node.ID, template.Node.Name})
+	}
+
+	createTableOutput("Templates", header, rows)
+
+	return nil
+}

--- a/internal/seed/config.go
+++ b/internal/seed/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	NumInvites int `json:"NumInvites" koanf:"NumInvites" default:"5"`
 	// NumSubscribers is the number of subscribers to generate
 	NumSubscribers int `json:"NumSubscribers" koanf:"NumSubscribers" default:"30"`
+	// GenerateTemplates is a flag to generate templates
+	GenerateTemplates bool `json:"generateTemplates" koanf:"generateTemplates" default:"true"`
 }
 
 // NewDefaultConfig returns a new Config with default values

--- a/internal/seed/datum.go
+++ b/internal/seed/datum.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/datumforge/datum/pkg/datumclient"
+	"github.com/datumforge/datum/pkg/enums"
 	"github.com/datumforge/datum/pkg/models"
 )
 
@@ -221,6 +222,34 @@ func (c *Client) RegisterUsers(ctx context.Context) error {
 				return err
 			}
 		}
+	}
+
+	return nil
+}
+
+// LoadTemplates loads the templates from the jsonschema/templates directory
+func (c *Client) LoadTemplates(ctx context.Context) error {
+	if !c.config.GenerateTemplates {
+		return nil
+	}
+
+	tmpls, err := getTemplates(templateDirectory)
+	if err != nil {
+		return err
+	}
+
+	input := []*datumclient.CreateTemplateInput{}
+
+	for _, t := range tmpls {
+		input = append(input, &datumclient.CreateTemplateInput{
+			Name:         t.Name,
+			Jsonconfig:   t.JSONConfig,
+			TemplateType: &enums.RootTemplate,
+		})
+	}
+
+	if _, err := c.CreateBulkTemplate(ctx, input); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/seed/errors.go
+++ b/internal/seed/errors.go
@@ -10,4 +10,7 @@ var (
 
 	// ErrColumnNotFound is returned when a column is not found in the CSV file
 	ErrColumnNotFound = fmt.Errorf("column not found in CSV file")
+
+	// ErrInvalidTemplateName is returned when an invalid template name is provided
+	ErrInvalidTemplateName = fmt.Errorf("invalid template name")
 )

--- a/internal/seed/templates.go
+++ b/internal/seed/templates.go
@@ -1,0 +1,62 @@
+package seed
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+const (
+	// templateNameNumParts represents the number of parts in a template name
+	// names are all formatted as datum.<name>.json
+	templateNameNumParts = 3
+)
+
+//go:embed templates/*/*.json
+var jsonSchemaFS embed.FS
+
+var (
+	templateDirectory = "templates/jsonschemas"
+)
+
+// Template represents a template to be seeded
+type Template struct {
+	// Name is the name of the template
+	Name string
+	// JSONConfig is the JSONschema configuration for the template
+	JSONConfig []byte
+}
+
+// getTemplates gets all the templates from the jsonschema directory
+func getTemplates(dir string) (templates []Template, err error) {
+	err = fs.WalkDir(jsonSchemaFS, dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if d == nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		schema, err := jsonSchemaFS.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		nameSplit := strings.Split(d.Name(), ".")
+
+		if len(nameSplit) != templateNameNumParts {
+			return fmt.Errorf("%w: %s", ErrInvalidTemplateName, d.Name())
+		}
+
+		templates = append(templates, Template{
+			Name:       nameSplit[1],
+			JSONConfig: schema,
+		})
+
+		return nil
+	})
+
+	return
+}

--- a/internal/seed/templates_test.go
+++ b/internal/seed/templates_test.go
@@ -1,0 +1,30 @@
+package seed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTemplates(t *testing.T) {
+	// Call the function being tested
+	templates, err := getTemplates(templateDirectory)
+	require.NoError(t, err)
+
+	// Check the number of templates
+	expectedNumTemplates := 1
+	assert.Len(t, templates, expectedNumTemplates)
+
+	// Check the template name and JSON config
+	for _, template := range templates {
+		assert.NotEmpty(t, template.Name)
+		assert.NotEmpty(t, template.JSONConfig)
+		assert.Contains(t, string(template.JSONConfig), "https://json-schema.org/draft/2020-12/schema")
+	}
+
+	// Call the function being tested, but include an invalid directory
+	templates, err = getTemplates("invalid")
+	require.Error(t, err)
+	assert.Nil(t, templates)
+}


### PR DESCRIPTION
- Adds document templates to the seed data, using templates in `jsonschema-templates` repo as a submodule
- Removes cli binary from commits, adds to `.gitignore`

```
+------------------------------------------+
| Templates                                |
+----------------------------+-------------+
| ID                         | NAME        |
+----------------------------+-------------+
| 01J1GCSSP230T310SPHEFTV00M | invoice     |
+----------------------------+-------------+
```