### PR TITLE
feat: add org members from registered users

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -137,10 +137,10 @@ tasks:
     desc: a task to create a personal access token and export it to the environment
     vars:
       PERSONAL_ORG:
-        sh: datum user get -z json | jq -r .users.edges.[0].node.setting.defaultOrg.id
+        sh: datum user get -z json | jq -r '.users.edges.[0].node.setting.defaultOrg.id'
     cmds:
       - touch {{.PAT_FILE}}
-      - datum pat create --name="datum-cloud-demo-env" --description="datum-cloud" -o {{.PERSONAL_ORG}} | jq -r '"DATUMCLOUD_PATID=\(.createPersonalAccessToken.personalAccessToken.id)\nDATUMCLOUD_SERVER_DATUM_TOKEN=\(.createPersonalAccessToken.personalAccessToken.token)\nDATUMCLOUD_TOKEN=\(.createPersonalAccessToken.personalAccessToken.token)"' > {{.PAT_FILE}}
+      - datum pat create --name="datum-cloud-demo-env" --description="datum-cloud" -o {{.PERSONAL_ORG}}  -z json | jq -r '"DATUMCLOUD_PATID=\(.createPersonalAccessToken.personalAccessToken.id)\nDATUMCLOUD_SERVER_DATUM_TOKEN=\(.createPersonalAccessToken.personalAccessToken.token)\nDATUMCLOUD_TOKEN=\(.createPersonalAccessToken.personalAccessToken.token)"' > {{.PAT_FILE}}
       - export $(awk -F= '{output=output" "$1"="$2} END {print output}' {{.PAT_FILE}})
 
   ## Server tasks

--- a/cmd/cli/cmd/seed/seed_init.go
+++ b/cmd/cli/cmd/seed/seed_init.go
@@ -62,7 +62,7 @@ func initSeedData(ctx context.Context) error {
 	bar.Describe("[light_green]>[reset] registering users...")
 	datumcloud.BarAdd(bar, 10) //nolint:mnd
 
-	err = c.RegisterUsers(ctx)
+	userIDs, err := c.RegisterUsers(ctx)
 	cobra.CheckErr(err)
 
 	bar.Describe("[light_green]>[reset] creating organizations...")
@@ -92,6 +92,12 @@ func initSeedData(ctx context.Context) error {
 
 	// create API Token for the root org and authorize as that token
 	err = c.GenerateSeedAPIToken(ctx, rootOrgID)
+	cobra.CheckErr(err)
+
+	bar.Describe("[light_green]>[reset] creating adding org members...")
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	err = c.LoadOrgMembers(ctx, userIDs)
 	cobra.CheckErr(err)
 
 	bar.Describe("[light_green]>[reset] creating groups...")

--- a/cmd/cli/cmd/seed/seed_orgmembers.go
+++ b/cmd/cli/cmd/seed/seed_orgmembers.go
@@ -1,0 +1,124 @@
+package datumseed
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/schollz/progressbar/v3"
+	"github.com/spf13/cobra"
+
+	datumcloud "github.com/datumforge/datum-cloud/cmd/cli/cmd"
+	"github.com/datumforge/datum-cloud/internal/seed"
+	"github.com/datumforge/datum/pkg/datumclient"
+)
+
+var seedOrgMembersCmd = &cobra.Command{
+	Use:   "org-members",
+	Short: "add users to an existing seeded organization",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return initOrgMemberData(cmd.Context())
+	},
+}
+
+func init() {
+	seedCmd.AddCommand(seedOrgMembersCmd)
+
+	seedOrgMembersCmd.Flags().StringP("organization-id", "o", "", "organization ID to add users to")
+	seedOrgMembersCmd.Flags().Int("users", defaultObjectCount, "number of users to generate")
+	seedOrgMembersCmd.Flags().StringP("patid", "t", "", "personal access token ID to authorize the organization")
+}
+
+func initOrgMemberData(ctx context.Context) error {
+	patID := datumcloud.Config.String("patid")
+	if patID == "" {
+		cobra.CheckErr("PAT ID not provided")
+	}
+
+	orgID := datumcloud.Config.String("organization-id")
+	if orgID == "" {
+		cobra.CheckErr("Organization ID not provided")
+	}
+
+	c, err := newSeedClient()
+	cobra.CheckErr(err)
+
+	// generate users in csv
+	config, err := seed.NewDefaultConfig()
+	cobra.CheckErr(err)
+
+	config.NumUsers = datumcloud.Config.Int("users")
+
+	config.GenerateUserData()
+
+	bar := progressbar.NewOptions(100, //nolint:mnd
+		progressbar.OptionEnableColorCodes(true),
+		progressbar.OptionShowBytes(false),
+		progressbar.OptionSetWidth(15), //nolint:mnd
+		progressbar.OptionShowElapsedTimeOnFinish(),
+		progressbar.OptionSetDescription("[light_green]>[reset] creating seeded org members..."),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "[light_green]=[reset]",
+			SaucerHead:    "[light_green]>[reset]",
+			SaucerPadding: " ",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}),
+	)
+	defer bar.Exit() //nolint:errcheck
+
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	bar.Describe("[light_green]>[reset] registering users...")
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	userIDs, err := c.RegisterUsers(ctx)
+	cobra.CheckErr(err)
+
+	err = c.AuthorizeOrganizationOnPAT(ctx, orgID, patID)
+	cobra.CheckErr(err)
+
+	// wait for the cache to update (1s)
+	// otherwise the user will not be able to see the org
+	time.Sleep(2 * time.Second) //nolint:mnd
+	datumcloud.BarAdd(bar, 10)  //nolint:mnd
+
+	// create API Token for the root org and authorize as that token
+	err = c.GenerateSeedAPIToken(ctx, orgID)
+	cobra.CheckErr(err)
+
+	bar.Describe("[light_green]>[reset] creating org members...")
+	datumcloud.BarAdd(bar, 10) //nolint:mnd
+
+	err = c.LoadOrgMembers(ctx, userIDs)
+	cobra.CheckErr(err)
+
+	bar.Describe("[light_green]>[reset] seeded environment created")
+	err = bar.Finish()
+	cobra.CheckErr(err)
+
+	return getAllOrgMemberData(ctx, c, orgID)
+}
+
+// getAllOrgMemberData gets all the data from the seeded environment in a table format
+func getAllOrgMemberData(ctx context.Context, c *seed.Client, orgID string) error {
+	members, err := c.GetOrgMembersByOrgID(ctx, &datumclient.OrgMembershipWhereInput{
+		OrganizationID: &orgID,
+	})
+	cobra.CheckErr(err)
+
+	header := table.Row{"ID", "Email", "Role"}
+	rows := []table.Row{}
+
+	for _, om := range members.OrgMemberships.Edges {
+		rows = append(rows, []interface{}{om.Node.ID, om.Node.User.Email, om.Node.Role})
+	}
+
+	// add empty row for spacing
+	fmt.Println()
+
+	createTableOutput("OrgMembers", header, rows)
+
+	return nil
+}

--- a/cmd/cli/cmd/seed/seed_orgmembers.go
+++ b/cmd/cli/cmd/seed/seed_orgmembers.go
@@ -9,9 +9,10 @@ import (
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
 
+	"github.com/datumforge/datum/pkg/datumclient"
+
 	datumcloud "github.com/datumforge/datum-cloud/cmd/cli/cmd"
 	"github.com/datumforge/datum-cloud/internal/seed"
-	"github.com/datumforge/datum/pkg/datumclient"
 )
 
 var seedOrgMembersCmd = &cobra.Command{
@@ -50,7 +51,8 @@ func initOrgMemberData(ctx context.Context) error {
 
 	config.NumUsers = datumcloud.Config.Int("users")
 
-	config.GenerateUserData()
+	err = config.GenerateUserData()
+	cobra.CheckErr(err)
 
 	bar := progressbar.NewOptions(100, //nolint:mnd
 		progressbar.OptionEnableColorCodes(true),

--- a/internal/seed/generate.go
+++ b/internal/seed/generate.go
@@ -34,3 +34,8 @@ func (c *Config) GenerateData() error {
 	// Generate the subscriber data
 	return c.generateSubscriberData()
 }
+
+func (c *Config) GenerateUserData() error {
+	// Generate the user data
+	return c.generateUserData()
+}


### PR DESCRIPTION
Adds the ability to register and add users to an org directly (vs. using invites):

```
 go run cmd/cli/main.go seed org-members --users 10 -o 01J31510E4BTW7MGX09CNYB2Y7 
> seeded environment created 100% [===============]  [3s]       
+---------------------------------------------------------------------+
| OrgMembers                                                          |
+----------------------------+-------------------------------+--------+
| ID                         | EMAIL                         | ROLE   |
+----------------------------+-------------------------------+--------+
| 01J360A41G674GJ3W87K72EXRC | kyleigh.kohler@example.com    | MEMBER |
| 01J360A41V3ND4C2T6DEJK0B14 | johnson.reilly@example.com    | MEMBER |
| 01J360A4255Q3HRT7WN88P400Q | reggie.howell@example.com     | MEMBER |
| 01J360A42ENSN8QXXNVX63W6AP | retta.cruickshank@example.com | MEMBER |
| 01J360A42SRC3Q9E6M1TN6RAEJ | jennyfer.windler@example.com  | MEMBER |
| 01J360A43281QMWEKTADXCVT2R | rita.boyer@example.com        | MEMBER |
| 01J360A439K6GDCHJA7RX7QMK0 | kenton.hamill@example.com     | MEMBER |
| 01J360A43GTJHYGQ3EGEWW05C5 | madonna.huel@example.com      | MEMBER |
| 01J360A43QYAWQ7ECP5G97GE0D | samara.stark@example.com      | MEMBER |
| 01J360A43YT9CTTHT2RJ665RPV | shaina.bogan@example.com      | MEMBER |
+----------------------------+-------------------------------+--------+
```